### PR TITLE
fix: missing `:action` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,10 @@ that gives:
     (:types type_1)
     (:constants a b c)
     (:predicates (p1 ?x ?y ?z) (p2 ?x ?y))
-    (:actions
-        (action-1
-            :parameters (?x ?y ?z)
-            :precondition (and (p1 ?x ?y ?z) (not (p2 ?y ?z)))
-            :effect (p2 ?y ?z)
-        )
+    (:action action-1
+        :parameters (?x ?y ?z)
+        :precondition (and (p1 ?x ?y ?z) (not (p2 ?y ?z)))
+        :effect (p2 ?y ?z)
     )
 )
 ```

--- a/pddl/core.py
+++ b/pddl/core.py
@@ -267,7 +267,7 @@ class Action:
 
     def __str__(self):
         """Get the string."""
-        operator_str = "({0}\n".format(self.name)
+        operator_str = "(:action {0}\n".format(self.name)
         operator_str += f"    :parameters ({' '.join(map(str, self.parameters))})\n"
         operator_str += f"    :precondition {str(self.precondition)}\n"
         operator_str += f"    :effect {str(self.effect)}\n"

--- a/pddl/formatter.py
+++ b/pddl/formatter.py
@@ -52,10 +52,7 @@ def domain_to_string(domain: Domain) -> str:
     body += _sort_and_print_collection("(:constants ", domain.constants, ")\n")
     body += _sort_and_print_collection("(:predicates ", domain.predicates, ")\n")
     body += _sort_and_print_collection(
-        "(:actions\n",
-        domain.actions,
-        ")\n",
-        to_string=lambda obj: indent(str(obj), indentation) + "\n",
+        "", domain.actions, "", to_string=lambda obj: str(obj) + "\n",
     )
     result = result + "\n" + indent(body, indentation) + "\n)"
     result = _remove_empty_lines(result)


### PR DESCRIPTION
## Proposed changes

During the conversion from PDDL domain to string, the actions were printed without the `:action` tag. This PR adds the tag and removes the (wrong) upper-level tag `:actions`

## Fixes

n/a

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/master/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a